### PR TITLE
OPENEUROPA-1590: Integrate Cookie Consent Kit when displaying videos from external providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "drupal/core": "^8.6",
         "drupal/entity_browser": "^2.0",
         "drupal/inline_entity_form": "^1.0",
-        "drupal/media_avportal": "1.x-dev"
+        "drupal/media_avportal": "1.x-dev",
+        "openeuropa/oe_webtools" : "dev-master"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "drupal/core": "^8.6",
         "drupal/entity_browser": "^2.0",
         "drupal/inline_entity_form": "^1.0",
-        "drupal/media_avportal": "1.x-dev",
-        "openeuropa/oe_webtools" : "dev-master"
+        "drupal/media_avportal": "1.x-dev"
     },
     "require-dev": {
         "composer/installers": "~1.5",
@@ -20,8 +19,9 @@
         "drupal/ctools": "^3.0",
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "^1.0.0-alpha4",
-        "openeuropa/task-runner": "~1.0.0-beta2",
         "openeuropa/drupal-core-require-dev": "^8.6",
+        "openeuropa/oe_webtools" : "dev-master",
+        "openeuropa/task-runner": "~1.0.0-beta2",
         "drupal/drupal-extension": "^4.0",
         "phpunit/phpunit": "~5.5||~6.0",
         "symfony/browser-kit": "~3.0||~4.0",

--- a/oe_media.module
+++ b/oe_media.module
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\media\IFrameMarkup;
+
 /**
  * Implements hook_media_source_info_alter().
  *
@@ -15,4 +17,26 @@ declare(strict_types = 1);
  */
 function oe_media_media_source_info_alter(array &$sources): void {
   $sources['oembed:video']['providers'] = ['YouTube', 'Vimeo', 'Dailymotion'];
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for media-oembed-iframe.html.twig template.
+ *
+ * According to fact that from oEmbed service we receive html code with iframe,
+ * we have to change "src" attribute value for cookie consent service usage.
+ */
+function oe_media_preprocess_media_oembed_iframe(array &$variables): void {
+  // Originally the cookie consent kit feature
+  // should be implemented in the oe_webtools_cookie_consent module.
+  // But cookie consent kit for remote videos doesn't have direct dependency
+  // from the oe_webtools_cookie_consent module.
+  // By enabling the oe_webtools_cookie_consent module we assume
+  // that we have to cover remote video functionality as well.
+  if ($variables['media'] instanceof IFrameMarkup && \Drupal::moduleHandler()->moduleExists('oe_webtools_cookie_consent')) {
+    preg_match('/<iframe.*src=["\']+([^"\']*)["\']+[^<>]*><\/iframe>/', $variables['media']->__toString(), $matches);
+    if (!empty($matches[1])) {
+      $new_iframe = str_replace($matches[1], '//ec.europa.eu/cookie-consent/iframe?oriurl=' . $matches[1] . '&lang=' . \Drupal::languageManager()->getCurrentLanguage()->getId(), $variables['media']);
+      $variables['media'] = IFrameMarkup::create($new_iframe);
+    }
+  }
 }

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -20,6 +20,7 @@ drupal:
     - "./vendor/bin/drush config-set node.settings use_admin_theme 1 -y"
     # Enable the modules.
     - "./vendor/bin/drush en oe_media oe_media_avportal oe_media_demo -y"
+    - "./vendor/bin/drush en oe_webtools_cookie_consent -y"
   settings:
     settings:
       file_scan_ignore_directories:

--- a/tests/Behat/DrupalContext.php
+++ b/tests/Behat/DrupalContext.php
@@ -129,4 +129,18 @@ class DrupalContext extends RawDrupalContext {
     $this->assertSession()->elementExists('css', "iframe[src*='$partial_iframe_url']");
   }
 
+  /**
+   * Checks that an OEmbed iframe url use CCK service.
+   *
+   * @param string $url
+   *   The video url.
+   *
+   * @Then I should see the oEmbed video iframe :url with cookie consent kit usage
+   */
+  public function assertOembedIframeWithCckUsage(string $url): void {
+    $iframe_url = $this->getSession()->getPage()->find('css', 'iframe')->getAttribute('src');
+    $this->visitPath(str_replace(rtrim($this->getDrupalParameter('drupal')['drupal_root'], '/'), '', $iframe_url));
+    $this->assertSession()->elementExists('css', "iframe[src^='//ec.europa.eu/cookie-consent/iframe?oriurl=']");
+  }
+
 }

--- a/tests/features/remote-video.feature
+++ b/tests/features/remote-video.feature
@@ -20,6 +20,7 @@ Feature: Remote video media entities.
     And I press "Save"
     Then I should see the heading "My Node"
     And I should see the embedded video player for "<url>"
+    And I should see the oEmbed video iframe "<url>" with cookie consent kit usage
 
     Examples:
       | url                                         | title                            |


### PR DESCRIPTION
## OPENEUROPA-1590

### Description
At the moment the OpenEuropa Media module can support a few video providers, other than AV Portal, like YouTube, Vimeo, etc.
When displaying videos form external providers (i.e. not AV Portal) we need to display the Cookie Consent Kit within the iframe.
Webtools documentation about this feature: https://webgate.ec.europa.eu/fpfis/wikis/pages/viewpage.action?spaceKey=webtools&title=Cookie+Consent+Kit
The NextEuropa platform implementation can be found in: multisite_cookie_consent module (https://github.com/ec-europa/platform/tree/master/lib/modules/custom/multisite_cookie_consent)

ToDo:
* Analyse the previous implementation. 
* Plan the new implementation, could be a new component. TBD
* Create followup tickets to implement and test the feature.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

