### PR TITLE
OPENEUROPA-1788: Fix problem on trying to edit existing remote video.

### DIFF
--- a/config/install/media.type.remote_video.yml
+++ b/config/install/media.type.remote_video.yml
@@ -16,4 +16,3 @@ source_configuration:
   source_field: oe_media_oembed_video
 field_map:
   title: name
-  url: oe_media_oembed_video

--- a/oe_media.install
+++ b/oe_media.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Contains installation hooks.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Updates mapping of remote video media type.
+ */
+function oe_media_update_8001() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('media.type.remote_video');
+  $config->clear('field_map.url');
+  $config->save();
+}


### PR DESCRIPTION
## OPENEUROPA-1788

### Description

Actual result:

Given I am logged in as a user with the "Author content" role
When I visit "the content/media page"
And I edit a remote video type
And I edit remote video URL with valid URL
Then I received an error 

Expected result (correct scenario):

Given I am logged in as a user with the "Author content" role
When I visit "the content/media page"
And I edit a remote video type
And I edit remote video URL with valid URL
And I press Save 
Then I should see the new remote video on the media list items
And I should see a success message
### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

