### PR TITLE
OPENEUROPA-1930: Update text filter parameter on view query.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/core": "^8.7",
         "drupal/entity_browser": "^2.0",
         "drupal/inline_entity_form": "^1.0",
-        "drupal/media_avportal": "^1.0"
+        "drupal/media_avportal": "^1.0-beta2"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/modules/oe_media_avportal/src/Plugin/views/query/AvPortalQuery.php
+++ b/modules/oe_media_avportal/src/Plugin/views/query/AvPortalQuery.php
@@ -140,7 +140,7 @@ class AVPortalQuery extends QueryPluginBase {
     foreach ($this->where as $where) {
       foreach ($where['conditions'] as $condition) {
         if ($condition['field'] == 'search') {
-          $options['kwand'] = $condition['value'];
+          $options['kwgg'] = $condition['value'];
         }
         if ($condition['field'] == 'type') {
           $types = [];


### PR DESCRIPTION
## OPENEUROPA-1930
### Description

The text filters on the AVPortal resource views don't work anymore.

The name of the parameters to filter by text changed on the end service so its been updated.

### Change log

- Added:
- Changed: Update text filter parameter on view query.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

