### PR TITLE
OPENEUROPA-1946: [oe_media] Document media type should use the private file system.

### DIFF
--- a/config/install/field.storage.media.oe_media_file.yml
+++ b/config/install/field.storage.media.oe_media_file.yml
@@ -12,7 +12,7 @@ settings:
   target_type: file
   display_field: false
   display_default: false
-  uri_scheme: public
+  uri_scheme: private
 module: file
 locked: false
 cardinality: 1

--- a/oe_media.module
+++ b/oe_media.module
@@ -7,6 +7,11 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
 /**
  * Implements hook_media_source_info_alter().
  *
@@ -18,96 +23,66 @@ function oe_media_media_source_info_alter(array &$sources): void {
 }
 
 /**
- * Implements hook_file_download().
+ * Implements hook_ENTITY_TYPE_access().
  *
- * Allow file downloading only if user have view access to parent entity (node).
+ * Check access to nodes with referencies to document media types.
  */
-function oe_media_file_download($uri) {
+function oe_media_media_access(EntityInterface $entity, string $operation, AccountInterface $account) {
+  if ($entity->bundle() !== 'document' || $operation !== 'view') {
+    return AccessResult::neutral()->cachePerUser();
+  }
+
   $entity_type_manager = \Drupal::entityTypeManager();
-  /* @var \Drupal\file\FileInterface[] $files */
-  $files = $entity_type_manager
-    ->getStorage('file')
-    ->loadByProperties(['uri' => $uri]);
 
-  if (count($files)) {
-    foreach ($files as $item) {
-      // Since some database servers sometimes use a case-insensitive comparison
-      // by default, double check that the filename is an exact match.
-      if ($item->getFileUri() === $uri) {
-        $file = $item;
-        break;
-      }
-    }
-  }
-  if (!isset($file)) {
-    return;
-  }
+  // Getting fields which could have references to 'document' media type.
+  // @TODO Check impact with possible usage of 'Entity Usage' module.
+  $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
+    'entity_type' => 'node',
+    'field_type' => 'entity_reference',
+  ]);
 
-  $usage = \Drupal::service('file.usage')->listUsage($file);
-
-  // Find out if a temporary file is still used in the system.
-  if ($file->isTemporary()) {
-    if (empty($usage) && $file->getOwnerId() != \Drupal::currentUser()->id()) {
-      // Deny access to temporary files without usage that are not owned by the
-      // same user. This prevents the security issue that a private file that
-      // was protected by field permissions becomes available after its usage
-      // was removed and before it is actually deleted from the file system.
-      // Modules that depend on this behavior should make the file permanent
-      // instead.
-      return -1;
+  $field_referenced_to_media = [];
+  /** @var \Drupal\field\Entity\FieldConfig $field */
+  foreach ($fields as $field) {
+    $field_settings = $field->getSettings();
+    if ($field_settings['handler'] === 'default:media' && in_array('document', $field_settings['handler_settings']['target_bundles'])) {
+      $field_referenced_to_media[] = $field->getName();
     }
   }
 
-  if ($file->isPermanent()) {
-    $referencing_entity_is_accessible = FALSE;
-    $references = $usage['file'] ?? [];
-    $media_ids = !empty($references['media']) ? array_keys($references['media']) : NULL;
+  // Get all nodes which use this media entity.
+  $query = \Drupal::entityQuery('node', 'OR');
+  foreach ($field_referenced_to_media as $field_name) {
+    $query->condition($field_name, $entity->id());
+  }
+  $nodes = $query->execute();
 
-    if (empty($media_ids)) {
-      return;
-    }
+  if (!$nodes) {
+    return AccessResult::neutral()->cachePerUser();
+  }
 
-    // Getting fields which could have references to 'document' media type.
-    // @TODO Check impact with possible usage of 'Entity Usage' module.
-    $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
-      'entity_type' => 'node',
-      'field_type' => 'entity_reference',
-    ]);
+  $referencing_node_entities = $entity_type_manager->getStorage('node')->loadMultiple(array_keys($nodes));
 
-    // Get all medias which use this file.
-    $field_referenced_to_media = [];
-    /** @var \Drupal\field\Entity\FieldConfig $field */
-    foreach ($fields as $field) {
-      $field_settings = $field->getSettings();
-      if ($field_settings['handler'] === 'default:media' && in_array('document', $field_settings['handler_settings']['target_bundles'])) {
-        $field_referenced_to_media[] = $field->getName();
-      }
-    }
-
-    // Get all medias which use this file.
-    $query = \Drupal::entityQuery('node', 'OR');
-    foreach ($field_referenced_to_media as $field_name) {
-      $query->condition($field_name, $media_ids);
-    }
-    $nodes = $query->execute();
-
-    $referencing_node_entities = $entity_type_manager->getStorage('node')->loadMultiple(array_keys($nodes));
-
-    // Check access to parent nodes.
-    foreach ($referencing_node_entities as $node_entity) {
-      if ($node_entity->access('view', NULL, TRUE)->isAllowed()) {
-        $referencing_entity_is_accessible = TRUE;
-        // Break, if user have access at least to one node.
-        break;
-      }
-    }
-
-    if (!$referencing_entity_is_accessible) {
-      return -1;
+  $referencing_entity_is_accessible = FALSE;
+  $accessible_node = FALSE;
+  // Check access to parent nodes.
+  foreach ($referencing_node_entities as $node_entity) {
+    if ($node_entity->access('view', NULL, TRUE)->isAllowed()) {
+      $referencing_entity_is_accessible = TRUE;
+      $accessible_node = $node_entity;
+      // Break, if user have access at least to one node.
+      break;
     }
   }
 
-  // Access is granted.
-  $headers = file_get_content_headers($file);
-  return $headers;
+  $access_result = AccessResult::forbiddenIf($referencing_entity_is_accessible === FALSE);
+
+  if ($accessible_node instanceof NodeInterface) {
+    $access_result->addCacheableDependency($accessible_node)->cachePerUser();
+  }
+  else {
+    $access_result->addCacheContexts(['user', 'node_list']);
+  }
+
+  return $access_result;
 }

--- a/oe_media.module
+++ b/oe_media.module
@@ -16,3 +16,93 @@ declare(strict_types = 1);
 function oe_media_media_source_info_alter(array &$sources): void {
   $sources['oembed:video']['providers'] = ['YouTube', 'Vimeo', 'Dailymotion'];
 }
+
+/**
+ * Implements hook_file_download().
+ *
+ * Allow file downloading only if user have view access to parent entity (node).
+ */
+function oe_media_file_download($uri) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  /* @var \Drupal\file\FileInterface[] $files */
+  $files = $entity_type_manager
+    ->getStorage('file')
+    ->loadByProperties(['uri' => $uri]);
+
+  if (count($files)) {
+    foreach ($files as $item) {
+      // Since some database servers sometimes use a case-insensitive comparison
+      // by default, double check that the filename is an exact match.
+      if ($item->getFileUri() === $uri) {
+        $file = $item;
+        break;
+      }
+    }
+  }
+  if (!isset($file)) {
+    return;
+  }
+
+  // Find out if a temporary file is still used in the system.
+  if ($file->isTemporary()) {
+    $usage = \Drupal::service('file.usage')->listUsage($file);
+    if (empty($usage) && $file->getOwnerId() != \Drupal::currentUser()->id()) {
+      // Deny access to temporary files without usage that are not owned by the
+      // same user. This prevents the security issue that a private file that
+      // was protected by field permissions becomes available after its usage
+      // was removed and before it is actually deleted from the file system.
+      // Modules that depend on this behavior should make the file permanent
+      // instead.
+      return -1;
+    }
+  }
+
+  $usage_list = \Drupal::service('file.usage')->listUsage($file);
+
+  if ($file->isPermanent()) {
+    $referencing_entity_is_accessible = FALSE;
+    $references = $usage_list['file'] ?? [];
+    $media_ids = !empty($references['media']) ? array_keys($references['media']) : NULL;
+
+    if (empty($media_ids)) {
+      return;
+    }
+
+    // Getting fields which could have references to 'document' media type.
+    $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
+      'entity_type' => 'node',
+      'field_type' => 'entity_reference',
+    ]);
+
+    $field_referenced_to_media = [];
+    /** @var \Drupal\field\Entity\FieldConfig $field */
+    foreach ($fields as $field) {
+      $field_settings = $field->getSettings();
+      if ($field_settings['handler'] === 'default:media' && in_array('document', $field_settings['handler_settings']['target_bundles'])) {
+        $field_referenced_to_media[] = $field->getName();
+      }
+    }
+
+    $query = \Drupal::entityQuery('node', 'OR');
+    foreach ($field_referenced_to_media as $field_name) {
+      $query->condition($field_name, $media_ids);
+    }
+    $nodes = $query->execute();
+
+    $referencing_node_entities = $entity_type_manager->getStorage('node')->loadMultiple(array_keys($nodes));
+
+    foreach ($referencing_node_entities as $node_entity) {
+      if ($node_entity->access('view', NULL, TRUE)->isAllowed()) {
+        $referencing_entity_is_accessible = TRUE;
+      }
+    }
+
+    if (!$referencing_entity_is_accessible) {
+      return -1;
+    }
+  }
+
+  // Access is granted.
+  $headers = file_get_content_headers($file);
+  return $headers;
+}

--- a/oe_media.module
+++ b/oe_media.module
@@ -43,9 +43,10 @@ function oe_media_file_download($uri) {
     return;
   }
 
+  $usage = \Drupal::service('file.usage')->listUsage($file);
+
   // Find out if a temporary file is still used in the system.
   if ($file->isTemporary()) {
-    $usage = \Drupal::service('file.usage')->listUsage($file);
     if (empty($usage) && $file->getOwnerId() != \Drupal::currentUser()->id()) {
       // Deny access to temporary files without usage that are not owned by the
       // same user. This prevents the security issue that a private file that
@@ -57,11 +58,9 @@ function oe_media_file_download($uri) {
     }
   }
 
-  $usage_list = \Drupal::service('file.usage')->listUsage($file);
-
   if ($file->isPermanent()) {
     $referencing_entity_is_accessible = FALSE;
-    $references = $usage_list['file'] ?? [];
+    $references = $usage['file'] ?? [];
     $media_ids = !empty($references['media']) ? array_keys($references['media']) : NULL;
 
     if (empty($media_ids)) {
@@ -69,11 +68,13 @@ function oe_media_file_download($uri) {
     }
 
     // Getting fields which could have references to 'document' media type.
+    // @TODO Check impact with possible usage of 'Entity Usage' module.
     $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
       'entity_type' => 'node',
       'field_type' => 'entity_reference',
     ]);
 
+    // Get all medias which use this file.
     $field_referenced_to_media = [];
     /** @var \Drupal\field\Entity\FieldConfig $field */
     foreach ($fields as $field) {
@@ -83,6 +84,7 @@ function oe_media_file_download($uri) {
       }
     }
 
+    // Get all medias which use this file.
     $query = \Drupal::entityQuery('node', 'OR');
     foreach ($field_referenced_to_media as $field_name) {
       $query->condition($field_name, $media_ids);
@@ -91,9 +93,12 @@ function oe_media_file_download($uri) {
 
     $referencing_node_entities = $entity_type_manager->getStorage('node')->loadMultiple(array_keys($nodes));
 
+    // Check access to parent nodes.
     foreach ($referencing_node_entities as $node_entity) {
       if ($node_entity->access('view', NULL, TRUE)->isAllowed()) {
         $referencing_entity_is_accessible = TRUE;
+        // Break, if user have access at least to one node.
+        break;
       }
     }
 

--- a/oe_media.module
+++ b/oe_media.module
@@ -8,9 +8,10 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_media_source_info_alter().
@@ -25,7 +26,8 @@ function oe_media_media_source_info_alter(array &$sources): void {
 /**
  * Implements hook_ENTITY_TYPE_access().
  *
- * Check access to nodes with referencies to document media types.
+ * Ensure that Document media access is derived from the nodes that reference
+ * them.
  */
 function oe_media_media_access(EntityInterface $entity, string $operation, AccountInterface $account) {
   if ($entity->bundle() !== 'document' || $operation !== 'view') {
@@ -33,9 +35,10 @@ function oe_media_media_access(EntityInterface $entity, string $operation, Accou
   }
 
   $entity_type_manager = \Drupal::entityTypeManager();
+  $cache = new CacheableMetadata();
+  $cache->addCacheTags(['node_list']);
 
   // Getting fields which could have references to 'document' media type.
-  // @TODO Check impact with possible usage of 'Entity Usage' module.
   $fields = $entity_type_manager->getStorage('field_config')->loadByProperties([
     'entity_type' => 'node',
     'field_type' => 'entity_reference',
@@ -50,39 +53,41 @@ function oe_media_media_access(EntityInterface $entity, string $operation, Accou
     }
   }
 
-  // Get all nodes which use this media entity.
-  $query = \Drupal::entityQuery('node', 'OR');
+  // Get all the nodes which use this media entity.
+  $query = $entity_type_manager->getStorage('node')->getQuery('OR');
   foreach ($field_referenced_to_media as $field_name) {
     $query->condition($field_name, $entity->id());
   }
   $nodes = $query->execute();
 
   if (!$nodes) {
-    return AccessResult::neutral()->cachePerUser();
+    return AccessResult::neutral()->addCacheableDependency($cache);
   }
 
   $referencing_node_entities = $entity_type_manager->getStorage('node')->loadMultiple(array_keys($nodes));
 
-  $referencing_entity_is_accessible = FALSE;
-  $accessible_node = FALSE;
-  // Check access to parent nodes.
-  foreach ($referencing_node_entities as $node_entity) {
-    if ($node_entity->access('view', NULL, TRUE)->isAllowed()) {
-      $referencing_entity_is_accessible = TRUE;
-      $accessible_node = $node_entity;
-      // Break, if user have access at least to one node.
-      break;
+  // Check access on the referencing nodes. If at least one of these returns
+  // access, we allow access as well. Otherwise, we deny it.
+  foreach ($referencing_node_entities as $node) {
+    $access = $node->access($operation, $account, TRUE);
+    $cache->addCacheableDependency($access);
+    if ($access instanceof AccessResultAllowed) {
+      // We only allow access if the user also can view media entities in
+      // general.
+      $view = AccessResult::allowedIfHasPermission($account, 'view media');
+      return $access->andIf($view)->addCacheableDependency($cache);
     }
   }
 
-  $access_result = AccessResult::forbiddenIf($referencing_entity_is_accessible === FALSE);
-
-  if ($accessible_node instanceof NodeInterface) {
-    $access_result->addCacheableDependency($accessible_node)->cachePerUser();
-  }
-  else {
-    $access_result->addCacheContexts(['user', 'node_list']);
+  // When denying access, we still allow access to users who can either
+  // administer media or own the media entity itself.
+  if ($account->hasPermission('administer media')) {
+    return AccessResult::neutral()->addCacheableDependency($cache);
   }
 
-  return $access_result;
+  if ($account->id() === $entity->getOwnerId()) {
+    return AccessResult::neutral()->addCacheableDependency($cache);
+  }
+
+  return AccessResult::forbidden()->addCacheableDependency($cache);
 }

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -26,7 +26,7 @@ drupal:
         - "vendor"
         - "${drupal.root}"
       extension_discovery_scan_tests: TRUE
-      file_private_path: "${drupal.root}/sites/default/files/private"
+      file_private_path: "sites/default/files/private"
 
 selenium:
   host: "http://selenium"

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -26,6 +26,7 @@ drupal:
         - "vendor"
         - "${drupal.root}"
       extension_discovery_scan_tests: TRUE
+      file_private_path: "${drupal.root}/sites/default/files/private"
 
 selenium:
   host: "http://selenium"

--- a/tests/Behat/DrupalContext.php
+++ b/tests/Behat/DrupalContext.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\oe_media\Behat;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\Core\Url;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -200,6 +201,46 @@ class DrupalContext extends RawDrupalContext {
     }
 
     return reset($nodes);
+  }
+
+  /**
+   * Navigates to the canonical page of a media entity.
+   *
+   * @param string $name
+   *   The title of the media.
+   *
+   * @When (I )go to the :name media page
+   * @When (I )visit the :name media page
+   */
+  public function visitMediaPage(string $name): void {
+    $media = $this->getMediaByName($name);
+    $this->visitPath($media->toUrl()->toString());
+  }
+
+  /**
+   * Retrieves a media entity by its name.
+   *
+   * @param string $name
+   *   The media name.
+   *
+   * @return \Drupal\media\MediaInterface
+   *   The media entity.
+   */
+  protected function getMediaByName(string $name): MediaInterface {
+    $storage = \Drupal::entityTypeManager()->getStorage('media');
+    $media = $storage->loadByProperties([
+      'name' => $name,
+    ]);
+
+    if (!$media) {
+      throw new \Exception("Could not find media with name '$name'.");
+    }
+
+    if (count($media) > 1) {
+      throw new \Exception("Multiple medias with name '$name' found.");
+    }
+
+    return reset($media);
   }
 
   /**

--- a/tests/features/document.feature
+++ b/tests/features/document.feature
@@ -4,9 +4,9 @@ Feature: Document media entities.
   As a site editor
   I want to be able to upload documents and reference Document media entities.
 
-  @cleanup:node @cleanup:media @cleanup:file @media-enable-standalone-url
+  @cleanup:node @cleanup:media @cleanup:file @media-enable-standalone-url @doc
   Scenario: Documents can be uploaded and attached to nodes.
-    Given I am logged in as a user with the "create oe_media_demo content, create document media" permissions
+    Given I am logged in as a user with the "administer nodes, create oe_media_demo content, edit own oe_media_demo content, view own unpublished content, create document media" permissions
     When I go to "the document creation page"
     Then I should see the heading "Add Document"
     When I fill in "Name" with "My Document 1"
@@ -21,6 +21,18 @@ Feature: Document media entities.
     And I press "Save"
     Then I should see the heading "My Node"
     And I should see the link "sample.pdf"
+    # Check inherited permissions for media file.
+    When I click "sample.pdf"
+    Then the response status code should be 200
+    And I go to the "My node" node page
+    When I click "Edit"
+    And I uncheck "Published"
+    And I press "Save"
+    And I click "sample.pdf"
+    Then the response status code should be 200
+    When I am an anonymous user
+    And I try to download the "My Document 1" media file
+    Then the response status code should be 403
 
   @javascript @cleanup:media @cleanup:file
   Scenario: The entity browser should allow the selection and creation of new Document Media entities

--- a/tests/features/document.feature
+++ b/tests/features/document.feature
@@ -4,7 +4,7 @@ Feature: Document media entities.
   As a site editor
   I want to be able to upload documents and reference Document media entities.
 
-  @cleanup:node @cleanup:media @cleanup:file @media-enable-standalone-url @doc
+  @cleanup:node @cleanup:media @cleanup:file @media-enable-standalone-url
   Scenario: Documents can be uploaded and attached to nodes.
     Given I am logged in as a user with the "administer nodes, create oe_media_demo content, edit own oe_media_demo content, view own unpublished content, create document media" permissions
     When I go to "the document creation page"
@@ -21,18 +21,24 @@ Feature: Document media entities.
     And I press "Save"
     Then I should see the heading "My Node"
     And I should see the link "sample.pdf"
-    # Check inherited permissions for media file.
-    When I click "sample.pdf"
-    Then the response status code should be 200
+
+    # Log out and check that we can see the media.
+    When I log out
+    And I go to the "My Document 1" media page
+    Then I should see the heading "My Document 1"
+
+    # Log back in and unpublish the node.
+    When I am logged in as a user with the "administer nodes, edit any oe_media_demo content" permission
     And I go to the "My node" node page
     When I click "Edit"
     And I uncheck "Published"
     And I press "Save"
-    And I click "sample.pdf"
-    Then the response status code should be 200
-    When I am an anonymous user
-    And I try to download the "My Document 1" media file
-    Then the response status code should be 403
+    Then I should see "My Node has been updated"
+
+    # Log back out and check that the media has no access.
+    When I log out
+    And I go to the "My Document 1" media page
+    Then I should see "Access denied"
 
   @javascript @cleanup:media @cleanup:file
   Scenario: The entity browser should allow the selection and creation of new Document Media entities


### PR DESCRIPTION
## OPENEUROPA-1946

### Description

Ensure that the uploaded files go to the private file system
Ensure that access to these files is controlled by the access to the node(s) that reference the media. Ask reported about implementation

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

