### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment:
       - DOCUMENT_ROOT=/test/oe_media
   mysql:
@@ -24,7 +24,7 @@ services:
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -32,7 +32,7 @@ pipeline:
 
   composer-update-lowest:
     group: prepare-update
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -44,25 +44,25 @@ pipeline:
         COMPOSER_BOUNDARY: lowest
 
   site-install:
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/run drupal:site-install
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/phpunit
 
   behat:
     group: test
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/behat --strict
 
@@ -70,3 +70,6 @@ matrix:
   COMPOSER_BOUNDARY:
     - lowest
     - highest
+  PHP_VERSION:
+    - 7.1
+    - 7.2

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "drush/drush": "~9.0",
         "drupal/json_field": "1.0-rc3",
         "drupal-composer/drupal-scaffold": "~2.5.2",
+        "guzzlehttp/guzzle": "~6.3",
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.0.0-beta2",
         "openeuropa/drupal-core-require-dev": "^8.7",
@@ -29,6 +30,9 @@
         "nikic/php-parser": "^3.1.5",
         "symfony/dom-crawler": "~3.4"
     },
+    "_readme": [
+        "We explicitly require guzzlehttp/guzzle to allow tests after 'composer update --prefer-lowest' to complete successfully."
+    ],
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,8 @@
         "phpunit/phpunit": "~6.0",
         "symfony/browser-kit": "~3.0||~4.0",
         "nikic/php-parser": "^3.1.5",
-        "symfony/dom-crawler": "~3.4",
-        "behat/mink-selenium2-driver": "dev-master#8684ee4 as 1.3.x-dev",
-        "behat/mink": "dev-master#a534fe7"
+        "symfony/dom-crawler": "~3.4"
     },
-     "_readme": [
-        "We need to alias a specific version of 'behat/mink-selenium2-driver' to '1.3.x-dev' since this branch is not available any longer. For more information check: https://github.com/minkphp/MinkSelenium2Driver/issues/313.",
-        "Upcoming ~1.4 of 'behat/mink-selenium2-driver' is known to have issues with latest 'behat/mink', so we need to pinpoint a specific version of the latter. For more information check: https://www.drupal.org/project/drupal/issues/3078671#comment-13244409."
-    ],
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.