### PR TITLE
OPENEUROPA-2663: Make sure that titles of av portal video is filtered.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,11 @@
             "build/modules/contrib/{$name}": [
                 "type:drupal-module"
             ]
+        },
+        "patches": {
+            "drupal/media_avportal": {
+                "latest-master": "https://patch-diff.githubusercontent.com/raw/openeuropa/media_avportal/pull/42.diff"
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         },
         "patches": {
             "drupal/media_avportal": {
-                "latest-master": "https://patch-diff.githubusercontent.com/raw/openeuropa/media_avportal/pull/42.diff"
+                "latest-8.x-1.x": "https://github.com/openeuropa/media_avportal/compare/8.x-1.0-beta5...8.x-1.x.diff"
             }
         }
     }

--- a/modules/oe_media_avportal/tests/modules/oe_media_avportal_test/responses/resources/I-163308.json
+++ b/modules/oe_media_avportal/tests/modules/oe_media_avportal_test/responses/resources/I-163308.json
@@ -22,8 +22,8 @@
         "ref": "I-163308",
         "duration": "4408.6",
         "titles_json": {
-          "FR": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
-          "EN": " LIVE \"Subsidiarity - as a building principle of the European Union\" Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
+          "FR": " LIVE <strong>\"Subsidiarity - as a building principle of the European Union\"</strong><br> Conference in Bregenz, Austria - Welcome, keynote speech and interviews",
+          "EN": " LIVE <strong>\"Subsidiarity - as a building principle of the European Union\"</strong><br> Conference in Bregenz, Austria - Welcome, keynote speech and interviews"
         },
         "summary_json": {
           "FR": "  - Welcome to the political segment by Gernot BLÜMEL, Austrian Federal Minister for the EU, Arts, Culture and Media - Keynote speech by  Frans TIMMERMANS, First Vice-President of the EC in charge of Better Regulation, Inter-Institutional Relations, the Rule of Law and the Charter of Fundamental Rights, and Chairman of the Task Force on Subsidiarity, Proportionality and \"Doing Less More Efficiently\" - Interviews Melania-Gabriela CIOT, Romania Secretary of State for European Affairs at the Ministry of Foreign Affairs Karl-Heinz LAMBERTZ, President of the Committee of the Regions Markus WALLNER, Landeshauptmann of Vorarlberg",


### PR DESCRIPTION
## OPENEUROPA-2663

### Description

All titles returned from AV Portal should be sanitised before displaying in the media browser

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

