### PR TITLE
OPENEUROA-2705: Display dailymotion thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Additionally, there is a demo module inside that exposes a content type and a ge
 ## Known Issues
 
 * The Daily Motion video URLs in the Remote video bundles need to have the HTTP scheme (not HTTPs).
+* The Daily Motion thumbnail URLs are typically without an extension so the local copy is not usable. This is fixed in [#3080666](https://www.drupal.org/project/drupal/issues/3080666) so if 
+your version of Drupal core does not include that commit yet, you can apply the latest patch there.
 
 ## Development setup
 

--- a/composer.json
+++ b/composer.json
@@ -64,12 +64,6 @@
             "build/modules/contrib/{$name}": [
                 "type:drupal-module"
             ]
-        },
-        "patches": {
-            "drupal/core": {
-                "https://www.drupal.org/project/drupal/issues/3080666": "https://www.drupal.org/files/issues/2020-02-04/3080666-9.patch"
-            }
         }
-
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         },
         "patches": {
             "drupal/core": {
-                "https://www.drupal.org/project/drupal/issues/3080666": "https://www.drupal.org/files/issues/2020-01-21/3080666-7.patch"
+                "https://www.drupal.org/project/drupal/issues/3080666": "https://www.drupal.org/files/issues/2020-01-27/3080666-8.patch"
             }
         }
 

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,12 @@
             "build/modules/contrib/{$name}": [
                 "type:drupal-module"
             ]
+        },
+        "patches": {
+            "drupal/core": {
+                "https://www.drupal.org/project/drupal/issues/3080666": "https://www.drupal.org/files/issues/2020-01-21/3080666-7.patch"
+            }
         }
+
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         },
         "patches": {
             "drupal/core": {
-                "https://www.drupal.org/project/drupal/issues/3080666": "https://www.drupal.org/files/issues/2020-01-27/3080666-8.patch"
+                "https://www.drupal.org/project/drupal/issues/3080666": "https://www.drupal.org/files/issues/2020-02-04/3080666-9.patch"
             }
         }
 


### PR DESCRIPTION
## OPENEUROPA-2705

### Description

Fix Oembed not properly using images without extensions.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed: Oembed thumbnails without extensions don't work with image styles
- Security:

### Commands

```sh
[Insert commands here]

```

