### PR TITLE
OPENEUROPA-3022: Access checks that rely on entity data should depend on the entity.

### DIFF
--- a/oe_media.module
+++ b/oe_media.module
@@ -33,7 +33,7 @@ function oe_media_media_source_info_alter(array &$sources): void {
  */
 function oe_media_media_access(EntityInterface $entity, string $operation, AccountInterface $account) {
   if ($operation === 'view' && !$entity->isPublished() && $account->hasPermission('view any unpublished media')) {
-    return AccessResult::allowed()->cachePerPermissions();
+    return AccessResult::allowed()->cachePerPermissions()->addCacheableDependency($entity);
   }
 
   if ($entity->bundle() !== 'document' || $operation !== 'view') {


### PR DESCRIPTION
I left a wrong remark in the previous PR, this one restores the cacheable dependency.