### PR TITLE
OPENEUROPA-0000: Use drupal/core instead of drupal/core-recommended.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "~7.2.0 || ~7.3.0",
-        "drupal/core-recommended": "^8.7",
+        "drupal/core": "^8.7",
         "drupal/entity_browser": "^2.0",
         "drupal/inline_entity_form": "^1.0",
         "drupal/media_avportal": "^1.0-beta6",


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

