### PR TITLE
OPENEUROPA-3364: Add cache dependency when rendering the media via the Filter.

### DIFF
--- a/modules/oe_media_embed/src/Plugin/Filter/FilterMediaEmbed.php
+++ b/modules/oe_media_embed/src/Plugin/Filter/FilterMediaEmbed.php
@@ -180,6 +180,8 @@ class FilterMediaEmbed extends FilterBase implements ContainerFactoryPluginInter
       }
     }
 
+    $result->addCacheableDependency($cache);
+
     $this->replaceNodeContent($node, $output);
   }
 


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

