### PR TITLE
OPENEUROPA-3327: Make basic and webtools media fields not translatable by default.

### DIFF
--- a/config/install/field.field.media.document.oe_media_file.yml
+++ b/config/install/field.field.media.document.oe_media_file.yml
@@ -13,7 +13,7 @@ bundle: document
 label: File
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/install/field.field.media.image.oe_media_image.yml
+++ b/config/install/field.field.media.image.oe_media_image.yml
@@ -13,7 +13,7 @@ bundle: image
 label: Image
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/install/field.field.media.remote_video.oe_media_oembed_video.yml
+++ b/config/install/field.field.media.remote_video.oe_media_oembed_video.yml
@@ -11,7 +11,7 @@ bundle: remote_video
 label: 'Remote video URL'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/oe_media_avportal/config/install/field.field.media.av_portal_photo.oe_media_avportal_photo.yml
+++ b/modules/oe_media_avportal/config/install/field.field.media.av_portal_photo.oe_media_avportal_photo.yml
@@ -11,7 +11,7 @@ bundle: av_portal_photo
 label: 'Media AV Portal Photo'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/oe_media_avportal/config/install/field.field.media.av_portal_video.oe_media_avportal_video.yml
+++ b/modules/oe_media_avportal/config/install/field.field.media.av_portal_video.oe_media_avportal_video.yml
@@ -11,7 +11,7 @@ bundle: av_portal_video
 label: 'Media AV Portal Video'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/oe_media_iframe/config/install/field.field.media.video_iframe.oe_media_iframe.yml
+++ b/modules/oe_media_iframe/config/install/field.field.media.video_iframe.oe_media_iframe.yml
@@ -11,7 +11,7 @@ bundle: video_iframe
 label: Iframe
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/oe_media_webtools/config/install/field.field.media.webtools_chart.oe_media_webtools.yml
+++ b/modules/oe_media_webtools/config/install/field.field.media.webtools_chart.oe_media_webtools.yml
@@ -13,7 +13,7 @@ bundle: webtools_chart
 label: 'Webtools chart snippet'
 description: 'Enter the snippet without the script tag. Snippets can be generated in <a href="https://europa.eu/webtools/mgmt/wizard/" target="_blank">Webtools wizard</a>.'
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/oe_media_webtools/config/install/field.field.media.webtools_map.oe_media_webtools.yml
+++ b/modules/oe_media_webtools/config/install/field.field.media.webtools_map.oe_media_webtools.yml
@@ -13,7 +13,7 @@ bundle: webtools_map
 label: 'Webtools map snippet'
 description: 'Enter the snippet without the script tag. Snippets can be generated in <a href="https://europa.eu/webtools/mgmt/wizard/" target="_blank">Webtools wizard</a>.'
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/oe_media_webtools/config/install/field.field.media.webtools_social_feed.oe_media_webtools.yml
+++ b/modules/oe_media_webtools/config/install/field.field.media.webtools_social_feed.oe_media_webtools.yml
@@ -13,7 +13,7 @@ bundle: webtools_social_feed
 label: 'Webtools social feed snippet'
 description: 'Enter the snippet without the script tag. Snippets can be generated in <a href="https://europa.eu/webtools/mgmt/wizard/" target="_blank">Webtools wizard</a>.'
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }


### PR DESCRIPTION
Media fields should not be translatable by default.