### PR TITLE
Change OR Query into OR Condition Group

### DIFF
--- a/oe_media.module
+++ b/oe_media.module
@@ -62,10 +62,13 @@ function oe_media_media_access(EntityInterface $entity, string $operation, Accou
   }
 
   // Get all the nodes which use this media entity.
-  $query = $entity_type_manager->getStorage('node')->getQuery('OR');
+  $query = $entity_type_manager->getStorage('node')->getQuery();
+  $orGroup = $query->orConditionGroup();
   foreach ($field_referenced_to_media as $field_name) {
-    $query->condition($field_name, $entity->id());
+    $orGroup->condition($field_name, $entity->id());
   }
+  $query->condition($orGroup);
+
   $ids = $query->execute();
 
   if (!$ids) {


### PR DESCRIPTION
### Description

The issue: The SQL query may get extended by other modules (contrib or custom) before getting executed. If the _OR_ conjunction is applied globally, everything that's being extended will be _OR_-ed. This will surely make the query incorrect.

Our case: _group_ contrib module is extending the _media_access_ hook with its own checks. Instead of constraining the query, it does the opposite because of the _OR_ conjunction. The result was that even if we have 1 field and 1 entity ID, the query would select **all** the nodes in the system. Given there are 100k+ nodes, the query would timeout.

### Change log

- Changed:
Moved the global _OR_ conjunction into an _OR_-ed condition group. This ensures that the _OR_ will get applied to the checked fields only. Any other checks will be added with _AND_ (the default).
