### PR TITLE
EWPP-303: Fix Behat step for Webtools JSON snippets in JS-enabled browsers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "composer/installers": "~1.5",
         "drush/drush": "~9.0",
         "drupal/json_field": "1.0-rc3",
+        "drupaltest/behat-traits": "~0.1",
         "drupal-composer/drupal-scaffold": "~2.5.2",
         "guzzlehttp/guzzle": "~6.3",
         "instaclick/php-webdriver": "^1.4.5",

--- a/tests/Behat/WebtoolsContext.php
+++ b/tests/Behat/WebtoolsContext.php
@@ -59,7 +59,9 @@ class WebtoolsContext extends RawDrupalContext {
   }
 
   /**
-   * Checks that the Webtools widget is exist on the page.
+   * Checks that the Webtools widget is present on the page.
+   *
+   * Asserts webtools json presence regardless the javascript availability.
    *
    * @param string $widget_type
    *   The webtools widget type.

--- a/tests/Behat/WebtoolsContext.php
+++ b/tests/Behat/WebtoolsContext.php
@@ -59,9 +59,9 @@ class WebtoolsContext extends RawDrupalContext {
   }
 
   /**
-   * Checks that the Webtools widget is present on the page.
+   * Checks that the Webtools JSON is present on the page.
    *
-   * Asserts Webtools JSON presence regardless the Javascript availability.
+   * Asserts the presence regardless of the Javascript availability.
    *
    * @param string $widget_type
    *   The webtools widget type.
@@ -93,28 +93,28 @@ class WebtoolsContext extends RawDrupalContext {
     // Assert presence of webtools JSON with enabled javascript.
     if (!$this->browserSupportsJavaScript()) {
       $this->assertSession()->elementsCount('xpath', $xpath_query, 1);
+      return;
     }
-    else {
-      // Retrieve the unprocessed page HTML with AJAX.
-      // JS-enabled drivers execute scripts that might modify the markup.
-      // In order to retrieve the unprocessed HTML, reload the page with AJAX,
-      // so all the cookies are passed. Note that this works
-      // only for pages loaded with GET.
-      $script = <<<JS
-        (function(window) {
-          var xhr = new XMLHttpRequest();
-          xhr.open('GET', window.location.href, false);
-          xhr.send();
-          return xhr.responseText;
-        })(window)
+
+    // Retrieve the unprocessed page HTML with AJAX.
+    // JS-enabled drivers execute scripts that might modify the markup. In order
+    // to retrieve the unprocessed HTML, reload the page with AJAX, so all the
+    // current session cookies are passed. Note that this works only for pages
+    // loaded with GET.
+    $script = <<<JS
+      (function(window) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', window.location.href, false);
+        xhr.send();
+        return xhr.responseText;
+      })(window);
 JS;
 
-      $raw_html = $this->getSession()->evaluateScript($script);
-      $doc = new \DOMDocument();
-      @$doc->loadHTML($raw_html);
-      $xpath = new \DOMXpath($doc);
-      Assert::assertCount(1, $xpath->query($xpath_query));
-    }
+    $raw_html = $this->getSession()->evaluateScript($script);
+    $doc = new \DOMDocument();
+    @$doc->loadHTML($raw_html);
+    $xpath = new \DOMXpath($doc);
+    Assert::assertCount(1, $xpath->query($xpath_query));
   }
 
 }


### PR DESCRIPTION
A new update of Webtools removes the script snippets if the loader is not autorised to be loaded in the current domain.
This prevents testing the presence of the snippets in JS-enabled browsers.