### PR TITLE
EWPP-441: Create assertion for Text with Featured media pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/core": "^8.7",
         "drupal/entity_browser": "^2.2",
         "drupal/inline_entity_form": "^1.0",
-        "drupal/media_avportal": "^1.0-beta6",
+        "drupal/media_avportal": "^1.0-beta9",
         "drupal/embed": "^1.0",
         "drupal/file_link": "^2.0.3"
     },


### PR DESCRIPTION
## EWPP-441

### Description

Set `"drupal/media_avportal": "^1.0-beta9"` as minimal version because this version introduced class `media-avportal-content` in AvPortalVideoFormatter. Html markup of iframe is different based on this class. We need to keep consistency in the output to write tests correctly.