### PR TITLE
ISSUE-160: Drupal 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.2",
-        "drupal/core": "^8.7",
         "drupal/entity_browser": "^2.2",
         "drupal/inline_entity_form": "^1.0",
         "drupal/media_avportal": "^1.0-beta9",

--- a/modules/oe_media_avportal/oe_media_avportal.info.yml
+++ b/modules/oe_media_avportal/oe_media_avportal.info.yml
@@ -2,7 +2,6 @@ name: OpenEuropa Media AV Portal
 description: Integrates the OpenEuropa Media module with the AV Portal service.
 package: OpenEuropa
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - oe_media:oe_media

--- a/modules/oe_media_avportal/oe_media_avportal.info.yml
+++ b/modules/oe_media_avportal/oe_media_avportal.info.yml
@@ -3,6 +3,7 @@ description: Integrates the OpenEuropa Media module with the AV Portal service.
 package: OpenEuropa
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - oe_media:oe_media
   - views:views

--- a/modules/oe_media_avportal/tests/modules/oe_media_avportal_test/oe_media_avportal_test.info.yml
+++ b/modules/oe_media_avportal/tests/modules/oe_media_avportal_test/oe_media_avportal_test.info.yml
@@ -1,5 +1,4 @@
 name: OpenEuropa Media AV Portal Test
-core: 8.x
 core_version_requirement: ^8 || ^9
 type: module
 dependencies:

--- a/modules/oe_media_avportal/tests/modules/oe_media_avportal_test/oe_media_avportal_test.info.yml
+++ b/modules/oe_media_avportal/tests/modules/oe_media_avportal_test/oe_media_avportal_test.info.yml
@@ -1,5 +1,6 @@
 name: OpenEuropa Media AV Portal Test
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 dependencies:
   - media_avportal:media_avportal_mock

--- a/modules/oe_media_demo/oe_media_demo.info.yml
+++ b/modules/oe_media_demo/oe_media_demo.info.yml
@@ -2,7 +2,6 @@ name: OpenEuropa Media Demo
 description: Demo module for the OpenEuropa media project.
 package: OpenEuropa
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:media

--- a/modules/oe_media_demo/oe_media_demo.info.yml
+++ b/modules/oe_media_demo/oe_media_demo.info.yml
@@ -3,6 +3,7 @@ description: Demo module for the OpenEuropa media project.
 package: OpenEuropa
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:media
   - oe_media:oe_media

--- a/modules/oe_media_embed/oe_media_embed.info.yml
+++ b/modules/oe_media_embed/oe_media_embed.info.yml
@@ -2,7 +2,6 @@ name: OpenEuropa Media Embed
 description: Provides the embed functionality of the media types
 package: OpenEuropa
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:views

--- a/modules/oe_media_embed/oe_media_embed.info.yml
+++ b/modules/oe_media_embed/oe_media_embed.info.yml
@@ -3,6 +3,7 @@ description: Provides the embed functionality of the media types
 package: OpenEuropa
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:views
   - media_avportal:media_avportal

--- a/modules/oe_media_embed/src/Form/MediaEmbedDialog.php
+++ b/modules/oe_media_embed/src/Form/MediaEmbedDialog.php
@@ -268,7 +268,7 @@ class MediaEmbedDialog extends FormBase {
     /** @var \Drupal\Core\Entity\EntityInterface $entity */
     $entity = $form_state->get('entity');
 
-    $form['#title'] = $this->t('Review selected @type', ['@type' => $entity->getEntityType()->getLowercaseLabel()]);
+    $form['#title'] = $this->t('Review selected @type', ['@type' => $entity->getEntityType()->getSingularLabel()]);
 
     $form['selection'] = [
       '#markup' => $entity->label(),

--- a/modules/oe_media_iframe/oe_media_iframe.info.yml
+++ b/modules/oe_media_iframe/oe_media_iframe.info.yml
@@ -3,7 +3,6 @@ description: 'Provides media types with iframe as media source.'
 package: OpenEuropa
 
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
 
 dependencies:

--- a/modules/oe_media_iframe/oe_media_iframe.info.yml
+++ b/modules/oe_media_iframe/oe_media_iframe.info.yml
@@ -4,6 +4,7 @@ package: OpenEuropa
 
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 
 dependencies:
   - drupal:filter

--- a/modules/oe_media_link_lists/oe_media_link_lists.info.yml
+++ b/modules/oe_media_link_lists/oe_media_link_lists.info.yml
@@ -3,6 +3,7 @@ description: Provides internal media support for manual link lists.
 package: OpenEuropa
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:media
   - oe_link_lists:oe_link_lists_manual_source

--- a/modules/oe_media_link_lists/oe_media_link_lists.info.yml
+++ b/modules/oe_media_link_lists/oe_media_link_lists.info.yml
@@ -2,7 +2,6 @@ name: OpenEuropa Media Link Lists
 description: Provides internal media support for manual link lists.
 package: OpenEuropa
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:media

--- a/modules/oe_media_webtools/oe_media_webtools.info.yml
+++ b/modules/oe_media_webtools/oe_media_webtools.info.yml
@@ -2,7 +2,6 @@ name: OpenEuropa Media Webtools
 description: Provides embeddable webtools media types.
 package: OpenEuropa
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:media

--- a/modules/oe_media_webtools/oe_media_webtools.info.yml
+++ b/modules/oe_media_webtools/oe_media_webtools.info.yml
@@ -3,6 +3,7 @@ description: Provides embeddable webtools media types.
 package: OpenEuropa
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:media
   - oe_webtools_media:oe_webtools_media

--- a/oe_media.info.yml
+++ b/oe_media.info.yml
@@ -3,6 +3,8 @@ description: Media features for the OpenEuropa project.
 package: OpenEuropa
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
+
 dependencies:
   - media:media
   - drupal:options

--- a/oe_media.info.yml
+++ b/oe_media.info.yml
@@ -2,9 +2,7 @@ name: OpenEuropa Media
 description: Media features for the OpenEuropa project.
 package: OpenEuropa
 type: module
-core: 8.x
 core_version_requirement: ^8 || ^9
-
 dependencies:
   - media:media
   - drupal:options

--- a/tests/modules/oe_media_oembed_mock/oe_media_oembed_mock.info.yml
+++ b/tests/modules/oe_media_oembed_mock/oe_media_oembed_mock.info.yml
@@ -1,5 +1,6 @@
 name: OpenEuropa oEmbed Media Test
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 dependencies:
   - oe_media:oe_media

--- a/tests/modules/oe_media_oembed_mock/oe_media_oembed_mock.info.yml
+++ b/tests/modules/oe_media_oembed_mock/oe_media_oembed_mock.info.yml
@@ -1,5 +1,4 @@
 name: OpenEuropa oEmbed Media Test
-core: 8.x
 core_version_requirement: ^8 || ^9
 type: module
 dependencies:


### PR DESCRIPTION
## ISSUE-160

### Description

Drupal 9 compatibility

### Change log

- Changed: 'core' key to 'core_version_requirement' key in info.yml files
- Removed 'drupal/core' dependency from composer.json
- Fixed: Reference to deprecated method: EntityTypeInferface::getLowercaseLabel() -> getSingularLabel()

