### PR TITLE
EWPP-1124: Change filter plugin id to avoid collision with core plugins.

### DIFF
--- a/modules/oe_media_embed/oe_media_embed.post_update.php
+++ b/modules/oe_media_embed/oe_media_embed.post_update.php
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\filter\Entity\FilterFormat;
 
 /**
  * Make view modes that are already available embeddable by default.
@@ -23,6 +24,29 @@ function oe_media_embed_post_update_00001(): void {
     if ($view_display->getThirdPartySetting('oe_media_embed', 'embeddable') === NULL) {
       $view_display->setThirdPartySetting('oe_media_embed', 'embeddable', TRUE);
       $view_display->save();
+    }
+  }
+}
+
+/**
+ * Update media embed filter plugin id.
+ */
+function oe_media_embed_post_update_00002(): void {
+  $available_formats = FilterFormat::loadMultiple();
+  /** @var \Drupal\filter\FilterFormatInterface $available_format */
+  foreach ($available_formats as $available_format) {
+    $filters = $available_format->get('filters');
+    foreach ($filters as $filter_id => $filter) {
+      if ($filter['provider'] == 'oe_media_embed' && $filter['id'] === 'media_embed') {
+        $filter['id'] = 'oe_media_embed';
+        $filters['oe_media_embed'] = $filter;
+        continue;
+      }
+    }
+    if (isset($filters['oe_media_embed'])) {
+      unset($filters['media_embed']);
+      $available_format->set('filters', $filters);
+      $available_format->save();
     }
   }
 }

--- a/modules/oe_media_embed/oe_media_embed.post_update.php
+++ b/modules/oe_media_embed/oe_media_embed.post_update.php
@@ -37,7 +37,7 @@ function oe_media_embed_post_update_00002(): void {
   foreach ($available_formats as $available_format) {
     $filters = $available_format->get('filters');
     foreach ($filters as $filter_id => $filter) {
-      if ($filter['provider'] == 'oe_media_embed' && $filter['id'] === 'media_embed') {
+      if ($filter['provider'] === 'oe_media_embed' && $filter['id'] === 'media_embed') {
         $filter['id'] = 'oe_media_embed';
         $filters['oe_media_embed'] = $filter;
         continue;

--- a/modules/oe_media_embed/src/Plugin/Filter/FilterMediaEmbed.php
+++ b/modules/oe_media_embed/src/Plugin/Filter/FilterMediaEmbed.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Provides a filter to convert PURL into internal urls/aliases.
  *
  * @Filter(
- *   id = "media_embed",
+ *   id = "oe_media_embed",
  *   title = @Translation("Embeds media entities using the oEmbed format"),
  *   type = Drupal\filter\Plugin\FilterInterface::TYPE_TRANSFORM_REVERSIBLE
  * )

--- a/modules/oe_media_embed/tests/src/Functional/MediaEmbedFilterTest.php
+++ b/modules/oe_media_embed/tests/src/Functional/MediaEmbedFilterTest.php
@@ -29,7 +29,7 @@ class MediaEmbedFilterTest extends MediaEmbedTestBase {
       'format' => 'format_with_embed',
       'name' => 'Format with embed',
       'filters' => [
-        'media_embed' => [
+        'oe_media_embed' => [
           'status' => 1,
         ],
       ],


### PR DESCRIPTION
## EWPP-1124
### Description

 Change embed_media filter plugin id to avoid collision with the embed_media core plugin.

### Change log

- Added:
- Changed:embed_media media renamed to oe_embed_media
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

