### PR TITLE
Issue #182: Also create missing field storages in update hook.

### DIFF
--- a/modules/oe_media_iframe/config/post_updates/00005_create_fields/field.storage.media.oe_media_iframe.yml
+++ b/modules/oe_media_iframe/config/post_updates/00005_create_fields/field.storage.media.oe_media_iframe.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.oe_media_iframe
+field_name: oe_media_iframe
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/oe_media_iframe/config/post_updates/00005_create_fields/field.storage.media.oe_media_iframe_ratio.yml
+++ b/modules/oe_media_iframe/config/post_updates/00005_create_fields/field.storage.media.oe_media_iframe_ratio.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - options
+id: media.oe_media_iframe_ratio
+field_name: oe_media_iframe_ratio
+entity_type: media
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '16_9'
+      label: '16:9'
+    -
+      value: '4_3'
+      label: '4:3'
+    -
+      value: '3_2'
+      label: '3:2'
+    -
+      value: '1_1'
+      label: '1:1'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/oe_media_iframe/config/post_updates/00005_create_fields/field.storage.media.oe_media_iframe_thumbnail.yml
+++ b/modules/oe_media_iframe/config/post_updates/00005_create_fields/field.storage.media.oe_media_iframe_thumbnail.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.oe_media_iframe_thumbnail
+field_name: oe_media_iframe_thumbnail
+entity_type: media
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/oe_media_iframe/oe_media_iframe.post_update.php
+++ b/modules/oe_media_iframe/oe_media_iframe.post_update.php
@@ -136,18 +136,34 @@ function oe_media_iframe_post_update_00004(): void {
 function oe_media_iframe_post_update_00005(): void {
   $file_storage = new FileStorage(drupal_get_path('module', 'oe_media_iframe') . '/config/post_updates/00005_create_fields');
 
-  $configs = [
-    'field.field.media.iframe.oe_media_iframe',
-    'field.field.media.iframe.oe_media_iframe_ratio',
-    'field.field.media.iframe.oe_media_iframe_thumbnail',
+  // The following fields might be missing in the 'iframe' media bundle.
+  $field_names = [
+    'oe_media_iframe',
+    'oe_media_iframe_ratio',
+    'oe_media_iframe_thumbnail',
   ];
-  $config_storage = \Drupal::entityTypeManager()->getStorage('field_config');
-  // Create fields if they do not exist.
-  foreach ($configs as $config) {
-    $config_data = $file_storage->read($config);
-    if (!$config_storage->load($config_data['id'])) {
-      $config_data['_core']['default_config_hash'] = Crypt::hashBase64(serialize($config_data));
-      $config_storage->create($config_data)->save();
+
+  // Create field storages, if they don't exist.
+  /** @var \Drupal\field\FieldStorageConfigStorage $field_storage_config_storage */
+  $field_storage_config_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
+  foreach ($field_names as $field_name) {
+    $field_storage_config_data = $file_storage->read('field.storage.media.' . $field_name);
+    if (!$field_storage_config_storage->load($field_storage_config_data['id'])) {
+      $field_storage_config_data['_core']['default_config_hash'] = Crypt::hashBase64(
+        serialize($field_storage_config_data));
+      $field_storage_config_storage->create($field_storage_config_data)->save();
+    }
+  }
+
+  // Create field instances, if they don't exist.
+  /** @var \Drupal\field\FieldStorageConfigStorage $field_config_storage */
+  $field_config_storage = \Drupal::entityTypeManager()->getStorage('field_config');
+  foreach ($field_names as $field_name) {
+    $field_config_data = $file_storage->read('field.field.media.iframe.' . $field_name);
+    if (!$field_config_storage->load($field_config_data['id'])) {
+      $field_config_data['_core']['default_config_hash'] = Crypt::hashBase64(
+        serialize($field_config_data));
+      $field_config_storage->create($field_config_data)->save();
     }
   }
 }


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]
(none yet)
The github issue is #182.

### Description
The update `oe_media_iframe_post_update_00005()` attempts to create missing fields (field instances) in the 'iframe' media bundle.
However, if the field bases (storages) are also missing, it will fail.
This happened in a project I am working on.

### Change in the PR
I am adding instructions in the update hook that also add the field storages, if they are missing.

How will this affect different projects?
- If the update hook has already run successfully, then we can assume the field storages were already there. So no need to do anything for those projects.
- If the field storages did not exist before, we assume that the hook has not run yet.

Therefore it seems safe to just add the instructions to the existing update hook, instead of adding a new update hook.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

