### PR TITLE
Added check to see if oe_media_image field exists, before copying the values.

### DIFF
--- a/oe_media.module
+++ b/oe_media.module
@@ -165,7 +165,7 @@ function oe_media_inline_entity_form_entity_form_alter(array &$entity_form, Form
  */
 function oe_media_media_presave(MediaInterface $media) {
   $source = $media->getSource();
-  if ($source instanceof Image) {
+  if ($source instanceof Image && $media->hasField('oe_media_image')) {
     // Ensure the image thumbnail alt is kept in sync with the image field alt.
     // Alt field is required, so we don't need to check if it's empty.
     // @see https://www.drupal.org/project/drupal/issues/3232414


### PR DESCRIPTION
## https://github.com/openeuropa/oe_media/issues/209

### Description

PR #206 introduces a bug where for each media type that is saved that isn't managed by oe_media, the code in hook_media_presave() is executed and breaks.
We have multiple media types that cannot be saved anymore because of this code. Therefore I have created a PR that simply checks if the oe_media_image field exists, before the values for the alt thumbnails are being read.

### Change log

- Added:
Check if the field exists before executing code.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

