### PR TITLE
D8EMA-1350: Remove CKEditor4 dependency.

### DIFF
--- a/modules/oe_media_embed/oe_media_embed.info.yml
+++ b/modules/oe_media_embed/oe_media_embed.info.yml
@@ -7,5 +7,4 @@ dependencies:
   - drupal:views
   - media_avportal:media_avportal
   - embed:embed
-  - drupal:ckeditor
   - oe_oembed:oe_oembed


### PR DESCRIPTION
## OPENEUROPA OE_MEDIA #233 

### Description

Removed CKEditor4 dependency not needed due to support added for CKEditor5 in oe_oembed.

### Change log

- Removed: CKEDitor4 dependency.