### PR TITLE
Fix full table select query if no referenced fields found

### DIFF
--- a/oe_media.module
+++ b/oe_media.module
@@ -67,6 +67,10 @@ function oe_media_media_access(EntityInterface $entity, string $operation, Accou
     }
   }
 
+  if (empty($field_referenced_to_media)) {
+    return AccessResult::neutral()->addCacheableDependency($cache);
+  }
+
   // Get all the nodes which use this media entity.
   $query = $entity_type_manager->getStorage('node')->getQuery('OR');
   foreach ($field_referenced_to_media as $field_name) {


### PR DESCRIPTION
## OPENEUROPA

Bug fix

### Description

[When none of the media types are used the code doesn't consider the full table select query. Selecting all the nodes can exhaust memory limit and cause any sorts of rendering problems.]

### Change log

- Added:
Added guard clause to early return if no referenced fields found.